### PR TITLE
add option not to cache specific http methods

### DIFF
--- a/lib/database_helper/database_helper.dart
+++ b/lib/database_helper/database_helper.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 
+import 'package:flutter/cupertino.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -16,6 +17,8 @@ class NetworkCacheSQLHelper {
   }
 
   NetworkCacheSQLHelper._internal();
+  @visibleForTesting
+  NetworkCacheSQLHelper.testing();
 
   Future<Database> get database async {
     if (_database != null) return _database!;

--- a/lib/database_helper/database_helper.dart
+++ b/lib/database_helper/database_helper.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/cupertino.dart' show visibleForTesting;
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 

--- a/test/network_cache_interceptor_test.dart
+++ b/test/network_cache_interceptor_test.dart
@@ -96,9 +96,9 @@ void main() {
 }
 
 /// Mock Database Helper for simulating cache storage
-class MockDatabaseHelper extends NetworkCacheSQLHelper {
+final class MockDatabaseHelper extends NetworkCacheSQLHelper {
   final Map<String, Map<String, dynamic>> _storage = {};
-
+  MockDatabaseHelper() : super.testing();
   @override
   Future<void> insertResponse(String key, Map<String, dynamic> value) async {
     _storage[key] = value;


### PR DESCRIPTION
This PR includes the option not to cache specific http methods. 

It falls into the same category as the option to not to cache specific http status codes.


The current state of the codebase implies to read the local cache only if it's a `GET` request. The write process does not handle that case. This PR fixes that und makes that as an option to the developer who uses this package in their codebase.


@JaysonKhan if you have any feedback feel free to ping me. Furthermore I would be happy if you would include this PR into your code. 